### PR TITLE
Added back-key (C64, left arrow - top left key on original keyboard),…

### DIFF
--- a/CBMTerm3/Forms/MainForm.cs
+++ b/CBMTerm3/Forms/MainForm.cs
@@ -465,6 +465,11 @@ namespace CBMTerm3
             {
                 switch (e.KeyCode)
                 {
+                    case Keys.Escape:
+                        Chrout(0x5F);         // C64 "←"
+                        e.SuppressKeyPress = true;
+                        break;
+
                     case Keys.Enter:
                         Chrout(0x0d);
                         e.SuppressKeyPress = true;


### PR DESCRIPTION
… since it is necessary for some BBSes to navigate back one level.